### PR TITLE
experimenting with context

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,3 +1,4 @@
 org.gradle.jvmargs=-Xmx1536M
 android.useAndroidX=true
 android.enableJetifier=true
+android.enableR8=true

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,8 +1,67 @@
 import 'package:flutter/material.dart';
 
 void main() {
-  runApp(MyApp());
+  runApp(App());
 }
+
+// This widget is the root of your application.
+class App extends StatefulWidget {
+  @override
+  _AppState createState() => _AppState();
+}
+
+class _AppState extends State<App> {
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: "Places app",
+      home: MyFirstWidget(),
+    );
+  }
+}
+
+class MyFirstWidget extends StatelessWidget {
+  int _counter = 0;
+
+  @override
+  Widget build(BuildContext context) {
+    _counter++;
+    print("the method from MyFirstWidget was called $_counter times");
+    return Container(
+      child: Center(
+        child: Text("Hello"),
+      ),
+    );
+  }
+
+// Type getContextType() => context.runtimeType;
+}
+
+class MyFirstStatefulWidget extends StatefulWidget {
+  @override
+  _MyFirstStatefulWidgetState createState() => _MyFirstStatefulWidgetState();
+
+// Type getContextType() => context.runtimeType;
+}
+
+class _MyFirstStatefulWidgetState extends State<MyFirstStatefulWidget> {
+  int _counter = 0;
+
+  @override
+  Widget build(BuildContext context) {
+    _counter++;
+    print(
+        "the method from _MyFirstStatefulWidgetState was called $_counter times");
+
+    return Container(
+      child: Center(
+        child: Text("Hello"),
+      ),
+    );
+  }
+}
+
+//------------------------------------------------------------------------------
 
 class MyApp extends StatelessWidget {
   // This widget is the root of your application.
@@ -112,47 +171,6 @@ class _MyHomePageState extends State<MyHomePage> {
         tooltip: 'Increment',
         child: Icon(Icons.add),
       ), // This trailing comma makes auto-formatting nicer for build methods.
-    );
-  }
-}
-
-class MyFirstWidget extends StatelessWidget {
-  int _counter = 0;
-
-  @override
-  Widget build(BuildContext context) {
-    // hot reload вызывает пересоздание виджета, значение переменной никуда не сохраняется,
-    // она инициалиируется заново и всегда будет = 1
-    _counter++;
-    print("the method from MyFirstWidget was called $_counter times");
-    return Container(
-      child: Center(
-        child: Text("Hello"),
-      ),
-    );
-  }
-}
-
-class MyFirstStatefulWidget extends StatefulWidget {
-  @override
-  _MyFirstStatefulWidgetState createState() => _MyFirstStatefulWidgetState();
-}
-
-class _MyFirstStatefulWidgetState extends State<MyFirstStatefulWidget> {
-  int _counter = 0;
-
-  @override
-  Widget build(BuildContext context) {
-    //  После hot reload значение переменной увеличивается на 1, так как
-    //  у StatefulWidget есть State, предназначенный как раз таки для сохранения состояния при пересоздании виджета
-    _counter++;
-    print(
-        "the method from _MyFirstStatefulWidgetState was called $_counter times");
-
-    return Container(
-      child: Center(
-        child: Text("Hello"),
-      ),
     );
   }
 }


### PR DESCRIPTION
1) При переименовании  файл `main.dart` и  старте через консоль получаем ошибку **Target file "lib/main.dart" not found**
Если переименовать файл `main.dart` через **Android Studio**,  то проект успешно запускается так как студия сама заменяет _entry point_

2) Не нашел место отображения **title**. Но судя по документации поле **title** на **android** отображается в заголовке приложения в диспетчере задач [ссылка на доку](https://api.flutter.dev/flutter/material/MaterialApp/title.html
)
3) В классе наследнике `StatelessWidget` нет доступа к контексту вне метода `build`

4) В классе наследнике `StatefulWidget` нет доступа к контексту
    Доступ к контексту есть в классе наследнике State